### PR TITLE
add missing dev dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "css-loader": "^0.23.1",
     "eslint": "^2.2.0",
     "eslint-config-airbnb": "^6.0.1",
+    "eslint-loader": "^1.5.0",
     "eslint-plugin-react": "^4.0.0",
     "extract-text-webpack-plugin": "^1.0.1",
     "gatsby": "^0.9.0",


### PR DESCRIPTION
`eslint-loader` was missing which crashed webpack server. 
